### PR TITLE
Custom output path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "kumono"
-version = "0.39.2"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kumono"
-version = "0.39.2"
+version = "0.40.0"
 edition = "2024"
 description = "Media ripper for coomer.su and kemono.su"
 homepage = "https://github.com/APT37/kumono"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,7 +11,7 @@ pub struct Args {
     #[arg(help = "Creator page or post / Discord server or channel")]
     pub urls: Vec<String>,
 
-    #[arg(short, long, default_value = ".", help = "Custom output path")]
+    #[arg(short, long, default_value = "./kumono/", help = "Custom output path")]
     pub output_path: Option<PathBuf>,
 
     #[arg(short, long, help = "Proxy URL (scheme://host:port[/path])")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,7 +11,7 @@ pub struct Args {
     #[arg(help = "Creator page or post / Discord server or channel")]
     pub urls: Vec<String>,
 
-    #[arg(short, long, default_value = "./kumono/", help = "Custom output path")]
+    #[arg(short, long, default_value = "kumono", help = "Custom output path")]
     pub output_path: PathBuf,
 
     #[arg(short, long, help = "Proxy URL (scheme://host:port[/path])")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,7 +12,7 @@ pub struct Args {
     pub urls: Vec<String>,
 
     #[arg(short, long, default_value = "./kumono/", help = "Custom output path")]
-    pub output_path: Option<PathBuf>,
+    pub output_path: PathBuf,
 
     #[arg(short, long, help = "Proxy URL (scheme://host:port[/path])")]
     pub proxy: Option<String>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 use clap::{ Parser, arg };
 use pretty_duration::pretty_duration;
-use serde::{ Deserialize };
-use std::{ fmt, num, sync::LazyLock, time::Duration };
+use serde::Deserialize;
+use std::{fmt, num, path::PathBuf, sync::LazyLock, time::Duration};
 
 pub static ARGS: LazyLock<Args> = LazyLock::new(Args::parse);
 
@@ -10,6 +10,9 @@ pub static ARGS: LazyLock<Args> = LazyLock::new(Args::parse);
 pub struct Args {
     #[arg(help = "Creator page or post / Discord server or channel")]
     pub urls: Vec<String>,
+
+    #[arg(short, long, default_value = ".", help = "Custom output path")]
+    pub output_path: Option<PathBuf>,
 
     #[arg(short, long, help = "Proxy URL (scheme://host:port[/path])")]
     pub proxy: Option<String>,

--- a/src/target.rs
+++ b/src/target.rs
@@ -134,7 +134,14 @@ impl Target {
     }
 
     pub fn to_pathbuf(&self, file: Option<&str>) -> PathBuf {
-        let mut path = PathBuf::from_iter(["kumono", &self.service, &self.user]);
+        let mut path = if let Some(output_path) = &ARGS.output_path {
+            output_path.clone()
+        } else {
+            PathBuf::from("kumono")
+        };
+
+        path.push(&self.service);
+        path.push(&self.user);
 
         if let Some(file) = file {
             path.push(file);

--- a/src/target.rs
+++ b/src/target.rs
@@ -134,10 +134,7 @@ impl Target {
     }
 
     pub fn to_pathbuf(&self, file: Option<&str>) -> PathBuf {
-        let mut path = ARGS.output_path.clone();
-
-        path.push(&self.service);
-        path.push(&self.user);
+        let mut path = PathBuf::from_iter([&ARGS.output_path, &self.service, &self.user]);
 
         if let Some(file) = file {
             path.push(file);

--- a/src/target.rs
+++ b/src/target.rs
@@ -134,11 +134,7 @@ impl Target {
     }
 
     pub fn to_pathbuf(&self, file: Option<&str>) -> PathBuf {
-        let mut path = if let Some(output_path) = &ARGS.output_path {
-            output_path.clone()
-        } else {
-            PathBuf::from("kumono")
-        };
+        let mut path = ARGS.output_path.clone();
 
         path.push(&self.service);
         path.push(&self.user);


### PR DESCRIPTION
This adds optional `--output-path`, `-o` flags which let the user provide a custom output path for the file tree that kumono generates.

If no custom path is provided, `./kumono/` will be used as default, same as the original behavior.
If a custom path `mypath` is provided, the output file tree will look like this: `mypath/service/user/`
