### PR TITLE
updated path buffer to maintain directory structure and ensure folders are created if they don't exist

### DIFF
--- a/src/target.rs
+++ b/src/target.rs
@@ -218,7 +218,7 @@ impl Target {
             &ARGS.output_path,
             &self.as_service().to_string(),
             &self.user(),
-        ]).with_file_name(file.unwrap_or_default())
+        ]).join(file.unwrap_or_default())
     }
 }
 


### PR DESCRIPTION
With the updated change to allow saving downloaded file hashes in an archive, I'm seeing an issue where files are now being saved directly to the service directory, and both skipping user folder creation or recognizing existing folders