### PR TITLE
Update regex to avoid capture of trailing dot

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -8,10 +8,7 @@ use std::{ error::Error, io::SeekFrom, path::PathBuf, sync::LazyLock };
 use tokio::{ fs::{ self, File }, io::{ AsyncSeekExt, AsyncWriteExt }, time::sleep };
 
 static HASH_RE: LazyLock<Regex> = LazyLock::new(|| 
-    Regex::new(r"^([0-9a-f]{64})(?:\..+)?$").unwrap()
-    // Matches:
-    // - Exactly 64 hex chars at the start (captured)
-    // - Optional: a dot followed by any extension (not captured)
+    Regex::new(r"^(?<hash>[0-9a-f]{64})(?:\..+)?$").unwrap()
 );
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -52,9 +49,7 @@ impl PostFile {
     }
 
     pub fn to_hash(&self) -> Option<String> {
-        HASH_RE.captures(&self.to_name())
-            .and_then(|caps| caps.get(1))
-            .map(|m| m.as_str().to_ascii_lowercase())
+        Some(HASH_RE.captures(&self.to_name())?.name("hash")?.as_str().to_string())
     }
 
     pub async fn open(&self, target: &Target) -> Result<File> {


### PR DESCRIPTION
had been encountering an issue where the hash mismatch function was being triggered. Used additional logging to compare expected and actual hashes and noticed the trailing dot for the file extension was being captured. 

Several examples : 
Hash mismatch for c306e87c2ff9c8666dad822a83f31b03bd44440a0681037d1d86751bb3fc081d.jpg: expected c306e87c2ff9c8666dad822a83f31b03bd44440a0681037d1d86751bb3fc081d., got c306e87c2ff9c8666dad822a83f31b03bd44440a0681037d1d86751bb3fc081d

Hash mismatch for bc51516eb67a671be705bf707b37509ace63d4540a4f90bd3ec6f6d6f717249a.jpg: expected bc51516eb67a671be705bf707b37509ace63d4540a4f90bd3ec6f6d6f717249a., got bc51516eb67a671be705bf707b37509ace63d4540a4f90bd3ec6f6d6f717249a

Hash mismatch for 188bbf2723d07a8fb0032b309df630ea251880b1c94a8fa68d1173e5c5a12ae0.jpg: expected 188bbf2723d07a8fb0032b309df630ea251880b1c94a8fa68d1173e5c5a12ae0., got 188bbf2723d07a8fb0032b309df630ea251880b1c94a8fa68d1173e5c5a12ae0
